### PR TITLE
Add Docker Compose deployment guide on README

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,16 +8,16 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+on      packages: write
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.2.0
+        uses: docker/setup-buildx-action@v3.7.1
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-on      packages: write
+      packages: write
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -17,7 +17,7 @@ on      packages: write
         uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.2.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,8 +13,11 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.2.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -31,6 +34,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/valospectra/overlay:latest

--- a/README.md
+++ b/README.md
@@ -13,4 +13,37 @@ It is comprised of three parts:
 
 Further updates for new features, as well as a detailed setup guide and an easy to host docker container are in the pipeline!
 
+# Docker Compose tutorial:
+
+First, create a seperate folder in your working directory and create a folder ``` config``` inside it:
+```
+mkdir -p spectra-frontend/config
+cd spectra-frontend
+```
+
+Create a file named docker-compose.yml as follow:
+```
+---
+services:
+  valo-spectra-frontend:
+    image: "ghcr.io/valospectra/overlay"
+    ports:
+      - "3000:80"
+    volumes:
+      - ./config:/usr/share/nginx/html/assets/config/
+```
+You can change ```3000``` to a different port which you want the frontend accessible outside the container to.
+
+Inside ``` config``` folder, create a file named ```config.json``` with the following content: 
+```
+{
+    "serverEndpoint": "https://localhost:5200"
+}
+```
+Replace ``` https://localhost:5200``` with your Spectra Server address and outcoming port (default is 5200).
+
+After that you can start the frontend by running ```docker compose up -d``` and the frontend are accessible at port ```3000``` by default.
+
+# DISCLAIMER
+
 Spectra-Client isn't endorsed by Riot Games and doesn't reflect the views or opinions of Riot Games or anyone officially involved in producing or managing Riot Games properties. Riot Games, and all associated properties are trademarks or registered trademarks of Riot Games, Inc.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mkdir -p spectra-frontend/config
 cd spectra-frontend
 ```
 
-Create a file named docker-compose.yml as follow:
+Create a file named ```docker-compose.yml``` as follow:
 ```
 ---
 services:


### PR DESCRIPTION
As the title, I created a small section in README that allow users to set frontend up more easily as they likely won't have to dive deep into the source code, or closed PR result in a merge in #4. In the future I would try to create a tutorial on Spectra-Server also.