### PR TITLE
Add redirect configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ It is comprised of three parts:
 
 Further updates for new features, as well as a detailed setup guide and an easy to host docker container are in the pipeline!
 
-# Docker Compose tutorial:
+# Docker Compose tutorial
 
-First, create a seperate folder in your working directory and create a folder ` config` inside it:
+First, create a seperate folder in your working directory and create a folder `config` inside it:
 
 ```
 mkdir -p spectra-frontend/config
@@ -43,6 +43,7 @@ Inside `config` folder, create a file named `config.json` with the following con
 ```
 {
   "serverEndpoint": "http://localhost:5200",
+  "redirectUrl": "https://valospectra.com",
   "sponsorImageUrls": ["/assets/misc/logo.webp"],
   "sponsorImageRotateSpeed": 5000,
   "attackerColorPrimary": "#b82e3c",

--- a/public/assets/config/config.json
+++ b/public/assets/config/config.json
@@ -1,6 +1,9 @@
 {
   "serverEndpoint": "http://localhost:5200",
-  "sponsorImageUrls": ["/assets/misc/logo.webp"],
+  "redirectUrl": "https://valospectra.com",
+  "sponsorImageUrls": [
+    "/assets/misc/logo.webp"
+  ],
   "sponsorImageRotateSpeed": 5000,
   "attackerColorPrimary": "#b82e3c",
   "attackerColorSecondary": "#ff4557",

--- a/src/app/redirect/redirect.component.ts
+++ b/src/app/redirect/redirect.component.ts
@@ -6,7 +6,7 @@ import { Config } from "../shared/config";
   template: ``,
 })
 export class RedirectComponent implements OnInit {
-  constructor(private config: Config) { }
+  constructor(private config: Config) {}
 
   ngOnInit() {
     window.location.href = this.config.redirectUrl;

--- a/src/app/redirect/redirect.component.ts
+++ b/src/app/redirect/redirect.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from "@angular/core";
+import { Config } from "../shared/config";
 
 @Component({
   selector: "app-redirect",
   template: ``,
 })
 export class RedirectComponent implements OnInit {
+  constructor(private config: Config) { }
+
   ngOnInit() {
-    window.location.href = "https://valospectra.com";
+    window.location.href = this.config.redirectUrl;
   }
 }

--- a/src/app/shared/config.ts
+++ b/src/app/shared/config.ts
@@ -1,5 +1,6 @@
 export class Config {
   serverEndpoint = "http://localhost:5200";
+  redirectUrl: string = "https://valospectra.com"
   sponsorImageUrls: string[] = [];
   sponsorImageRotateSpeed = 5000; // in milliseconds
 

--- a/src/app/shared/config.ts
+++ b/src/app/shared/config.ts
@@ -1,6 +1,6 @@
 export class Config {
   serverEndpoint = "http://localhost:5200";
-  redirectUrl: string = "https://valospectra.com"
+  redirectUrl = "https://valospectra.com";
   sponsorImageUrls: string[] = [];
   sponsorImageRotateSpeed = 5000; // in milliseconds
 


### PR DESCRIPTION
In self-hosted environments, you might want to use a different redirect than the official valospectra website.