### PR TITLE
refactor(docker): improve ability to develop using docker locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 ---
 services:
   valo-spectra-frontend:
-    image: valospectra/overlay
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: node:22-alpine
+    entrypoint: sh -c 'corepack enable && yarn run start-docker'
+    working_dir: /app
+    volumes:
+      - ./:/app
+      - /var/www/.angular
     ports:
       - "3000:80"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --configuration development",
+    "start-docker": "ng serve --port=80 --host 0.0.0.0",
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
This will change the current requirement of rebuilding the docker image and instead use the command normally used for development. The advantages of this are that it will automatically rebuild with new changes like normal, but still would offer the possibility to add something like a `traefik` reverse proxy for local development so it can be unified between environments. 

Also, people who are used to just running `docker compose up` can do that for local development too.